### PR TITLE
Add factory registration for top-level blocks

### DIFF
--- a/src/peakrdl_uvm/templates/uvm_reg_block-mem.sv
+++ b/src/peakrdl_uvm/templates/uvm_reg_block-mem.sv
@@ -7,6 +7,7 @@
 {%- if class_needs_definition(node) %}
 // {{get_class_friendly_name(node)}}
 class {{get_class_name(node)}} extends uvm_reg_block;
+    `uvm_object_utils({{get_class_name(node)}})
 {%- if use_uvm_factory %}
     `uvm_object_utils({{get_class_name(node)}})
 {%- endif %}

--- a/src/peakrdl_uvm/templates/uvm_reg_block.sv
+++ b/src/peakrdl_uvm/templates/uvm_reg_block.sv
@@ -7,6 +7,7 @@
 {%- if class_needs_definition(node) %}
 // {{get_class_friendly_name(node)}}
 class {{get_class_name(node)}} extends uvm_reg_block;
+    `uvm_object_utils({{get_class_name(node)}})
 {%- if use_uvm_factory %}
     `uvm_object_utils({{get_class_name(node)}})
 {%- endif %}


### PR DESCRIPTION
This PR adds factory registration for register blocks.
UVM encourages registering component and object classes with the factory. While it's not necessary to register *all* classes (eg individual registers), registering top-level classes is a good compromise. 
In my case, the UVM tool I use to create environments (UVM Framework) assumes that the top-level register block can be created via the factory.
