### PR TITLE
Configure virtual register arrays inside memories using offset argument

### DIFF
--- a/src/peakrdl_uvm/templates/uvm_vreg.sv
+++ b/src/peakrdl_uvm/templates/uvm_vreg.sv
@@ -65,6 +65,6 @@ this.{{get_inst_name(node)}} = {{get_class_name(node)}}::type_id::create("{{get_
 {%- else %}
 this.{{get_inst_name(node)}} = new("{{get_inst_name(node)}}");
 {%- endif %}
-this.{{get_inst_name(node)}}.configure(this, this.m_mem, {{node.inst.n_elements}});
+this.{{get_inst_name(node)}}.configure(this, this.m_mem, {{node.inst.n_elements}}, {{node.raw_address_offset}} / 8);
 this.{{get_inst_name(node)}}.build();
 {%- endmacro %}


### PR DESCRIPTION
`configure` method of `uvm_vreg` accepts an `offset` argument which is useful especially when we try to declare a virtual register array inside a memory block in systemRDL. Example case below

```
mem my_mem{
    name = "My Memory";
    mementries = 1024*128; // 1MB space
    memwidth = 64;

    reg {
        name = "ArrayA";
        regwidth = 64;
        field {
            name = "An array of values in a particular address of memory";
        } value[63:0];
    } arrayA[32] @ 0x100;

    reg {
        name = "ArrayB";
        regwidth = 64;
        field {
            name = "Different array of values in a different address";
        } value[63:0];
    } arrayB[32] @ 0x200;
```

This patch allows us to use `peakrdl-uvm` to still generate a useful UVM-RAL with correct offsets. Without this, compilation errors out complaining that there are multiple virtual registers trying to occupy the same address.

Link to `uvm_vreg` configure method:  https://verificationacademy.com/verification-methodology-reference/uvm/docs_1.1a/html/files/reg/uvm_vreg-svh.html#uvm_vreg.configure